### PR TITLE
Set up custom errors for CLI, execution, and validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ There are roughly 70 commands available for use, so you're encouraged to check o
 - `vault` - Manage account vaults
 - `user` - Manage account users
 - `group` - Manage groups and their users
+- `whoami` - Get details about the authenticated account
 
 ## License
 


### PR DESCRIPTION
Currently all errors are surfaced by op-js as a standard `Error` instance. We should make these errors more easily identifiable and useful.

This PR introduces some new error types:

**`ValidationError`**:
- Instantiate with `"not-found"` to denote when the `op` executable can't be located
- Instantiate with `"version"` as well as the required and current versions to denote when the CLI does satisfy the required version. The required and current versions will be attached so they can be inspected.

**`ExecutionError`**:
- This is just to clarify when the command actually failed to execute, versus the CLI producing an error response

**`CLIError`**:
- Largely added so we can attach the status/exit code of an `op` command when throwing an error. CLI error messages can potentially have sensitive info in them, so we want avoid printing/logging them verbatim. By attaching the exit code the application can at least identify the _type_ of error and produce it's own relevant error message.
- For times when you do want to display the actual error message it also parses the error message into useful parts.

For example, this error message:

```
[ERROR] 2022/06/04 17:59:15 authorization prompt dismissed, please try again
```

Will be parsed into:
- `message` equaling `"authorization prompt dismissed, please try again"`
- `timestamp` as a `Date` instance of "2022/06/04 17:59:15"