### PR TITLE
Pass user agent details to CLI, add helper that allows it to be overriden

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { cli, Flags } from "./cli";
+import { cli, ClientInfo, Flags } from "./cli";
 
 type CommandFlags<TOptional extends Flags = {}> = Partial<
 	TOptional & GlobalFlags
@@ -22,6 +22,14 @@ export interface GlobalFlags {
 	isoTimestamps: boolean;
 	sessionToken: string;
 }
+
+/**
+ * Set user agent information passed to the CLI.
+ *
+ * Note: this is intended for internal usage; using could result in unexpected behaviour
+ */
+export const setClientInfo = (clientInfo: ClientInfo) =>
+	cli.setClientInfo(clientInfo);
 
 /**
  * Set any of the {@link GlobalFlags} on the CLI command.


### PR DESCRIPTION
1Password CLI will start collecting simple usage information via user agent. To support this op-js is going to specify a few environment variables for the CLI to pick up:

- `OP_INTEGRATION_NAME`: "1Password for JavaScript"
- `OP_INTEGRATION_ID`: "JS"
- `OP_INTEGRATION_BUILDNUMBER` (numeric)

Official clients that use op-js (such as the VS Code extension) need to be able to override these details, so we also expose a new helper function that can do this (note: currently this should only be used by official clients; arbitrary UA info may be rejected by the CLI).

Side note - while it will take a newer version of the CLI to start collecting this data, user-facing functionality remains unchanged, so we are not updating the recommended version number at this time (used as required version in the VS Code extension)