### PR TITLE
bump default CLI version to 2.6.2

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -137,7 +137,7 @@ export const defaultClientInfo: ClientInfo = {
 };
 
 export class CLI {
-	public static recommendedVersion = ">=2.4.0";
+	public static recommendedVersion = ">=2.6.2";
 	public clientInfo: ClientInfo = defaultClientInfo;
 	public globalFlags: Partial<GlobalFlags> = {};
 


### PR DESCRIPTION
Bumps `recommendedVersion` to [1Password CLI 2.6.2](https://app-updates.agilebits.com/product_history/CLI2#v2060201)