### PR TITLE
Support item creation across CLI versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Note that you should not try to set the `--format` flag as this is set under the
 
 ### Validating the CLI
 
-Since this package depends on the 1Password CLI it's up to the user to install it, and the types may depend on a specific version. The minimum supported CLI version is 2.6.2. There is a function that your application can call to validate that the user has the CLI installed at a specific version:
+Since this package depends on the 1Password CLI it's up to the user to install it, and the types may depend on a specific version. There is a function that your application can call to validate that the user has the CLI installed at a specific version:
 
 ```js
 import { validateCli } from "@1password/op-js";

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"prepare": "husky install",
 		"prettier": "prettier --check 'src/*.ts'",
 		"test:unit": "jest --testMatch '<rootDir>/src/*.test.ts'",
-		"test:integration": "jest --testMatch '<rootDir>/tests/*.test.ts' --setupFilesAfterEnv '<rootDir>/jest.setup.ts'",
+		"test:integration": "jest --testMatch '<rootDir>/tests/*.test.ts' --setupFilesAfterEnv '<rootDir>/jest.setup.ts' --runInBand",
 		"typecheck": "tsc -p tsconfig.release.json --noEmit",
 		"watch": "yarn compile --watch"
 	},

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -259,7 +259,7 @@ describe("cli", () => {
 		});
 
 		it("does not throw when cli is fully valid", async () => {
-			CLI.recommendedVersion = CLI.minimumSupportedVersion;
+			CLI.recommendedVersion = ">=2.0.0";
 
 			const lookpathSpy = jest
 				.spyOn(lookpath, "lookpath")
@@ -269,7 +269,7 @@ describe("cli", () => {
 				.mockReturnValue({
 					error: null,
 					stderr: "",
-					stdout: CLI.minimumSupportedVersion,
+					stdout: "2.1.0",
 				});
 
 			await expect(cli.validate()).resolves.toBeUndefined();
@@ -279,7 +279,7 @@ describe("cli", () => {
 		});
 
 		it("can handle beta versions", async () => {
-			CLI.recommendedVersion = CLI.minimumSupportedVersion;
+			CLI.recommendedVersion = ">=2.0.0";
 
 			const lookpathSpy = jest
 				.spyOn(lookpath, "lookpath")
@@ -289,7 +289,7 @@ describe("cli", () => {
 				.mockReturnValue({
 					error: null,
 					stderr: "",
-					stdout: `${CLI.minimumSupportedVersion}.beta.12`,
+					stdout: "2.0.1.beta.12",
 				});
 
 			await expect(cli.validate()).resolves.toBeUndefined();
@@ -307,10 +307,10 @@ describe("cli", () => {
 				.mockReturnValue({
 					error: null,
 					stderr: "",
-					stdout: CLI.minimumSupportedVersion,
+					stdout: "2.1.0",
 				});
 
-			await expect(cli.validate(">=2.6.2")).resolves.toBeUndefined();
+			await expect(cli.validate(">=2.0.0")).resolves.toBeUndefined();
 
 			lookpathSpy.mockRestore();
 			spawnSpy.mockRestore();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@ export interface ClientInfo {
 
 export class ValidationError extends Error {
 	public constructor(
-		type: "not-found" | "version" | "min-supported-version",
+		type: "not-found" | "version",
 		public requiredVersion?: string,
 		public currentVersion?: string,
 	) {
@@ -37,9 +37,6 @@ export class ValidationError extends Error {
 				break;
 			case "version":
 				message = `CLI version ${currentVersion} does not satisfy required version ${requiredVersion}`;
-				break;
-			case "min-supported-version":
-				message = `CLI version ${currentVersion} does not satisfy the minimum supported version ${requiredVersion}`;
 				break;
 		}
 
@@ -141,7 +138,6 @@ export const defaultClientInfo: ClientInfo = {
 
 export class CLI {
 	public static recommendedVersion = ">=2.6.2";
-	public static minimumSupportedVersion = ">=2.6.2";
 	public clientInfo: ClientInfo = defaultClientInfo;
 	public globalFlags: Partial<GlobalFlags> = {};
 
@@ -158,16 +154,6 @@ export class CLI {
 
 		if (!cliExists) {
 			throw new ValidationError("not-found");
-		}
-
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-		const requiredVersionSemVer = semverCoerce(requiredVersion);
-		if (!semverSatisfies(requiredVersionSemVer, CLI.minimumSupportedVersion)) {
-			throw new ValidationError(
-				"min-supported-version",
-				CLI.minimumSupportedVersion,
-				requiredVersion,
-			);
 		}
 
 		const version = this.getVersion();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -137,7 +137,7 @@ export const defaultClientInfo: ClientInfo = {
 };
 
 export class CLI {
-	public static recommendedVersion = ">=2.6.2";
+	public static recommendedVersion = ">=2.4.0";
 	public clientInfo: ClientInfo = defaultClientInfo;
 	public globalFlags: Partial<GlobalFlags> = {};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,7 +245,7 @@ export interface Document {
 		id: string;
 		name: string;
 	};
-	last_edited_by: string;
+	last_edited_by?: string;
 	created_at: string;
 	updated_at: string;
 	"overview.ainfo"?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -896,6 +896,9 @@ export const item = {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
 		const version = semverCoerce(cli.getVersion());
 
+		// Prior to 2.6.2 the CLI didn't handle field assignments correctly
+		// within scripts, so if we're below that version we need to pipe the
+		// fields in via stdin
 		if (semverSatisfies(version, ">=2.6.2")) {
 			options.args = assignments;
 		} else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -885,8 +885,27 @@ export const item = {
 	) =>
 		cli.execute<Item>(["item", "create"], {
 			flags,
-			args: assignments,
+			// NOTE: There is an issue in the CLI that prevents us from using field assignments
+			// in `item create` through Node. I don't know what it is or why it's so specific,
+			// but until then we will need to pipe in the fields as a JSON object. This does not
+			// appear to impact `item edit`.
+			stdin: {
+				fields: assignments.map(([label, type, value, purpose]) => {
+					const data = {
+						label,
+						type,
+						value,
+					};
+
+					if (purpose) {
+						Object.assign(data, { purpose });
+					}
+
+					return data;
+				}),
+			},
 		}),
+
 	/**
 	 * Permanently delete an item.
 	 *

--- a/src/index.ts
+++ b/src/index.ts
@@ -805,8 +805,8 @@ export type PasswordField = ValueField & {
 	purpose: "PASSWORD";
 	entropy: number;
 	password_details: {
-		entropy: number;
-		generated: boolean;
+		entropy?: number;
+		generated?: boolean;
 		strength: PasswordStrength;
 	};
 };

--- a/tests/document.test.ts
+++ b/tests/document.test.ts
@@ -29,7 +29,7 @@ describe("document", () => {
 						id: Joi.string().required().allow(""),
 						name: Joi.string().allow(""),
 					},
-					last_edited_by: Joi.string().required(),
+					last_edited_by: Joi.string().optional(),
 					created_at: Joi.string().required(),
 					updated_at: Joi.string().required(),
 					"overview.ainfo": Joi.string(),

--- a/tests/item.test.ts
+++ b/tests/item.test.ts
@@ -34,8 +34,8 @@ const itemSchema = Joi.object({
 			tags: Joi.array().items(Joi.string().required()).optional(),
 			entropy: Joi.number().optional(),
 			password_details: Joi.object({
-				entropy: Joi.number().required(),
-				generated: Joi.boolean().required(),
+				entropy: Joi.number().optional(),
+				generated: Joi.boolean().optional(),
 				strength: Joi.string().required(),
 			})
 				.optional()


### PR DESCRIPTION
I've decided to revert https://github.com/1Password/op-js/pull/64 and instead handle item creation based on the version of `op` you're using, as we want to be able to keep using new releases with op-vscode, but do not want to force users into a newer version of the CLI.

So if you're using >= 2.6.2, where we fixed how to handle item creation without using piped input, your command will use field assignments. If you're using below that version, you'll continue to use piped JSON input.

PR also updates some property expectations in the integration tests, and switches to sequential integration test running to prevent flaky conflicts.