### PR TITLE
"Fix" inject command for Mac/Linux

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -348,6 +348,17 @@ describe("cli", () => {
 			);
 		});
 
+		it("throws on invalid args", () => {
+			expect(() =>
+				executeSpy([
+					["foo"],
+					{
+						args: [null],
+					},
+				]),
+			).toThrowError(new TypeError("Invalid argument"));
+		});
+
 		it("sanitizes input in commands, arguments, and flags", () => {
 			const execute = executeSpy([
 				['"foo'],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ export type FlagValue =
 	| FieldLabelSelector
 	| FieldTypeSelector;
 export type Flags = Record<string, FlagValue>;
-type Arg = string | null | FieldAssignment;
+type Arg = string | FieldAssignment;
 
 export interface ClientInfo {
 	name: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -183,10 +183,9 @@ export class CLI {
 				// If it's an array assume it's a field assignment
 			} else if (Array.isArray(arg)) {
 				parts.push(createFieldAssignment(arg));
+			} else {
+				throw new TypeError("Invalid argument");
 			}
-
-			// arg can be null, but that's just so we can lazily
-			// set the value, safely dropping if it remains null
 		}
 
 		if (json) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ export type FlagValue =
 	| FieldLabelSelector
 	| FieldTypeSelector;
 export type Flags = Record<string, FlagValue>;
+type Arg = string | null | FieldAssignment;
 
 export interface ClientInfo {
 	name: string;
@@ -85,6 +86,9 @@ export const camelToHyphen = (str: string) =>
 
 export const sanitizeInput = (str: string) =>
 	str.replace(/(["$'\\`])/g, "\\$1");
+
+const equalArray = (a: any[], b: any[]) =>
+	a.length === b.length && a.every((val, index) => val === b[index]);
 
 export const parseFlagValue = (value: FlagValue) => {
 	if (typeof value === "string") {
@@ -165,29 +169,20 @@ export class CLI {
 		}
 	}
 
-	public execute<TData extends string | Record<string, any> | void>(
-		command: string[],
-		{
-			args = [],
-			flags = {},
-			stdin,
-			json = true,
-		}: {
-			args?: (string | null | FieldAssignment)[];
-			flags?: Flags;
-			stdin?: string | Record<string, any>;
-			json?: boolean;
-		} = {},
-	): TData {
-		let input: NodeJS.ArrayBufferView;
-		command = command.map((part) => sanitizeInput(part));
+	private createParts(
+		subCommand: string[],
+		args: Arg[],
+		flags: Flags,
+		json: boolean,
+	): string[] {
+		const parts = subCommand.map((part) => sanitizeInput(part));
 
 		for (const arg of args) {
 			if (typeof arg === "string") {
-				command.push(sanitizeInput(arg));
+				parts.push(sanitizeInput(arg));
 				// If it's an array assume it's a field assignment
 			} else if (Array.isArray(arg)) {
-				command.push(createFieldAssignment(arg));
+				parts.push(createFieldAssignment(arg));
 			}
 
 			// arg can be null, but that's just so we can lazily
@@ -198,13 +193,51 @@ export class CLI {
 			flags = { ...flags, format: "json" };
 		}
 
-		command = [
-			...command,
+		// Version >=2.6.2 of the CLI changed how it handled piped input
+		// in order to fix an issue with item creation, but in the process
+		// it broke piping for other commands. We have a macOS/Linux-only
+		// workaround, but not one for Windows, so for now we cannot support
+		// the inject command on Windows past this version until the CLI
+		// team fixes the issue.
+		if (equalArray(subCommand, ["inject"])) {
+			const version = semverCoerce(cli.getVersion());
+			if (semverSatisfies(version, ">=2.6.2")) {
+				if (process.platform === "win32") {
+					throw new ExecutionError(
+						"Inject is not supported on Windows for version >=2.6.2 of the CLI",
+						1,
+					);
+				} else {
+					flags = { ...flags, inFile: "/dev/stdin" };
+				}
+			}
+		}
+
+		return [
+			...parts,
 			...createFlags({
 				...this.globalFlags,
 				...flags,
 			}),
 		];
+	}
+
+	public execute<TData extends string | Record<string, any> | void>(
+		subCommand: string[],
+		{
+			args = [],
+			flags = {},
+			stdin,
+			json = true,
+		}: {
+			args?: Arg[];
+			flags?: Flags;
+			stdin?: string | Record<string, any>;
+			json?: boolean;
+		} = {},
+	): TData {
+		let input: NodeJS.ArrayBufferView;
+		const parts = this.createParts(subCommand, args, flags, json);
 
 		if (stdin) {
 			input = Buffer.from(
@@ -212,7 +245,7 @@ export class CLI {
 			);
 		}
 
-		const { status, error, stdout, stderr } = spawnSync("op", command, {
+		const { status, error, stdout, stderr } = spawnSync("op", parts, {
 			stdio: "pipe",
 			input,
 			env: {

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -1,0 +1,24 @@
+import Joi from "joi";
+import { inject, item } from "../src";
+
+describe("inject", () => {
+	describe("data", () => {
+		it("returns injected data", () => {
+			const value = "bar";
+			const injectable = item.create([["foo", "text", value]], {
+				vault: process.env.OP_VAULT,
+				category: "Login",
+				title: "Injectable",
+			});
+			const reference = injectable.fields.find(
+				(f) => f.label === "foo",
+			).reference;
+
+			const result = inject.data(`foo ${reference}`);
+			expect(result).toMatchSchema(Joi.string().required());
+			expect(result).toEqual(`foo ${value}`);
+
+			item.delete(injectable.id);
+		});
+	});
+});


### PR DESCRIPTION
This PR adds a "fix" for `inject` commands that call `op inject` under the hood. Currently, if you're using a version >= 2.6.2 you'll get an error:

`expected data on stdin but none found`.

It's a little unfortunate, but in CLI v2.6.2, when we addressed piping data into commands for item creation we somehow broke input for the inject command. The CLI team has helped me address this in macOS/Linux environments by supplying `--in-file /dev/stdin`, but there isn't an equivelent for Windows. This means that on or after v2.6.2, if you're using Windows, inject commands through op-js do not work.

There is an internal ticket {2899} to address the problem across platforms, but since we're at v2.7.1 now we need to address the issue as best we can.