### PR TITLE
Updates to error classes

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,9 +25,10 @@ export interface ClientInfo {
 	build: string;
 }
 
+export type ValidationErrorType = "not-found" | "version";
 export class ValidationError extends Error {
 	public constructor(
-		public type: "not-found" | "version",
+		public type: ValidationErrorType,
 		public requiredVersion?: string,
 		public currentVersion?: string,
 	) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,7 +27,7 @@ export interface ClientInfo {
 
 export class ValidationError extends Error {
 	public constructor(
-		type: "not-found" | "version",
+		public type: "not-found" | "version",
 		public requiredVersion?: string,
 		public currentVersion?: string,
 	) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import semverCoerce from "semver/functions/coerce";
 import semverSatisfies from "semver/functions/satisfies";
 import { cli, ClientInfo, CLIError, Flags } from "./cli";
 
+export { CLIError, ExecutionError, ValidationError } from "./cli";
+
 type CommandFlags<TOptional extends Flags = {}> = Partial<
 	TOptional & GlobalFlags
 >;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,12 @@ import semverCoerce from "semver/functions/coerce";
 import semverSatisfies from "semver/functions/satisfies";
 import { cli, ClientInfo, CLIError, Flags } from "./cli";
 
-export { CLIError, ExecutionError, ValidationError } from "./cli";
+export {
+	CLIError,
+	ExecutionError,
+	ValidationError,
+	ValidationErrorType,
+} from "./cli";
 
 type CommandFlags<TOptional extends Flags = {}> = Partial<
 	TOptional & GlobalFlags


### PR DESCRIPTION
Quick PR to update our usage of error classes in op-js:

- Make ValidationError type property accessible
- Export CLIError, ExecutionError, ValidationError from main bundle

Both of these are helpful to the end-user when scripting with the package in case they want to inspect errors.

Closes #85
Closes #84