### PR TITLE
Add setConnect function to set Connect Server details for auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ validateCli(">=2.3.1").catch((error) => {
 });
 ```
 
+### Authentication
+
+By default `op-js` uses system authentication (e.g. biometrics), but it also supports automated authentication via [Connect Server](https://developer.1password.com/docs/connect).
+
+If you've got a Connect Server set up you can supply your host and token:
+
+```
+import { setConnect } from "@1password/op-js";
+
+setConnect("https://connect.myserver.com", "1kjhd9872hd981865s");
+```
+
+Alternatively you can use environment variables when executing the code that uses `op-js`:
+
+```
+OP_CONNECT_HOST=https://connect.myserver.com
+OP_CONNECT_TOKEN=1kjhd9872hd981865s
+```
+
 ### Available commands and functions
 
 There are roughly 70 commands available for use, so you're encouraged to check out the main [`index.ts`](./src/index.ts) file to get a better sense of what's available. Generally, though, here are the top-level commands/namespaces you can import:

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -225,6 +225,36 @@ describe("cli", () => {
 		});
 	});
 
+	describe("connect", () => {
+		it("does not set connect env vars if not supplied", () => {
+			cli.connect = undefined;
+
+			const execute = executeSpy([["foo"]]);
+			const envVars = Object.keys(execute.call[2].env);
+
+			expect(envVars).not.toContain("OP_CONNECT_HOST");
+			expect(envVars).not.toContain("OP_CONNECT_TOKEN");
+		});
+
+		it("passes connect env vars if supplied", () => {
+			cli.connect = {
+				host: "https://connect.myserver.com",
+				token: "1kjhd9872hd981865s",
+			};
+
+			const execute = executeSpy([["foo"]]);
+			expect(execute.call[2].env).toEqual(
+				expect.objectContaining({
+					OP_CONNECT_HOST: cli.connect.host,
+					OP_CONNECT_TOKEN: cli.connect.token,
+				}),
+			);
+
+			// Reset connect info
+			cli.connect = undefined;
+		});
+	});
+
 	describe("validate", () => {
 		it("throws an error when the op cli is not found", async () => {
 			const lookpathSpy = jest

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -145,6 +145,7 @@ export class CLI {
 	public static recommendedVersion = ">=2.4.0";
 	public clientInfo: ClientInfo = defaultClientInfo;
 	public globalFlags: Partial<GlobalFlags> = {};
+	public connect?: { host: string; token: string };
 
 	public setClientInfo(clientInfo: ClientInfo) {
 		this.clientInfo = clientInfo;
@@ -250,6 +251,10 @@ export class CLI {
 			input,
 			env: {
 				...process.env,
+				...(this.connect && {
+					OP_CONNECT_HOST: this.connect.host,
+					OP_CONNECT_TOKEN: this.connect.token,
+				}),
 				OP_INTEGRATION_NAME: this.clientInfo.name,
 				OP_INTEGRATION_ID: this.clientInfo.id,
 				OP_INTEGRATION_BUILDNUMBER: this.clientInfo.build,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,17 @@ export const setGlobalFlags = (flags: Partial<GlobalFlags>) => {
 	cli.globalFlags = flags;
 };
 
+/**
+ * Set a Connect host and token
+ *
+ * Alternative to running with `OP_CONNECT_HOST` and `OP_CONNECT_TOKEN` set
+ *
+ * {@link https://developer.1password.com/docs/connect/}
+ */
+export const setConnect = (host: string, token: string) => {
+	cli.connect = { host, token };
+};
+
 // Section: CLI setup
 
 /**


### PR DESCRIPTION
Closes https://github.com/1Password/op-js/issues/77

This PR adds support for supplying Connect Server host and token.

All it's doing is applying them as env vars, and does not preclude the ability to set these values via env vars yourself.