### PR TITLE
Export semverToInt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { cli, ClientInfo, CLIError, Flags } from "./cli";
 export {
 	CLIError,
 	ExecutionError,
+	semverToInt,
 	ValidationError,
 	ValidationErrorType,
 } from "./cli";


### PR DESCRIPTION
This function is now exported so that other pakcages that use op-js (e.g. [vscode extension](https://github.com/1Password/op-vscode) and [load-secrets-action](https://github.com/1Password/load-secrets-action/pull/36)) can easily convert a version to a build number.