### PR TITLE
Fixed #105 - Section interface should have a label field

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -774,6 +774,7 @@ export interface FieldTypeSelector {
 
 export interface Section {
 	id: string;
+	label?: string;
 }
 
 interface BaseField {


### PR DESCRIPTION
Sorry for the chaos in the last PR.
Added label string as an optional variable field in the Section interface.
In the op-js/src/index.ts file
I have made the following changes. Please review it and let me know if any further changes are required :)
![image](https://github.com/1Password/op-js/assets/50038492/efebb9be-c75e-4b38-9030-e91776c684cd)


@jodyheavener Are there any other issues you feel like I can work one? Please let me know. Would love to work on new issues

Thank you 