### PR TITLE
Do not bundle code with esbuild during compile step

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"license": "MIT",
 	"scripts": {
 		"build": "license-checker-rseidelsohn --direct --files licenses && yarn compile --minify && tsc -p tsconfig.release.json --emitDeclarationOnly",
-		"compile": "esbuild --bundle --platform=node --outdir=dist src/index.js",
+		"compile": "esbuild --platform=node --outdir=dist src/index.js",
 		"eslint": "eslint -c .eslintrc.json 'src/*.ts'",
 		"prepare": "husky install",
 		"prettier": "prettier --check 'src/*.ts'",


### PR DESCRIPTION
Related: https://github.com/1Password/op-js/issues/146

Context: This package uses [esbuild](https://esbuild.github.io/). Up until now we have been bundling the code in this package. This is [not necessary](https://esbuild.github.io/getting-started/#bundling-for-node) as the package is always used in a Node environment, and can even be detrimental to the end user who may wish to patch a specific version of a dependency. 

This PR simply removes the `--bundle` flag in the compile step.

Note: this PR does not address the semver dependency noted in the referenced issue.