### PR TITLE
Explicitly set CJS format, inputs when compiling

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"license": "MIT",
 	"scripts": {
 		"build": "license-checker-rseidelsohn --direct --files licenses && yarn compile --minify && tsc -p tsconfig.release.json --emitDeclarationOnly",
-		"compile": "esbuild --platform=node --outdir=dist src/index.js",
+		"compile": "esbuild src/index.ts src/cli.ts --platform=node --format=cjs --outdir=dist",
 		"eslint": "eslint -c .eslintrc.json 'src/*.ts'",
 		"prepare": "husky install",
 		"prettier": "prettier --check 'src/*.ts'",


### PR DESCRIPTION
Fixes https://github.com/1Password/op-js/issues/153

In #152 we stopped bundling all dependencies in the package. As it turns out, bundling was ensuring an all-CJS format and it was incorporating not only external deps but relative files. By removing bundling and not explicitly marking the format as CJS we inadvertently introduced ESM syntax and omitted relative files. [More info here.](https://esbuild.github.io/api/#platform)

>When the platform is set to node:
>
>- When [bundling](https://esbuild.github.io/api/#bundle) is enabled the default output [format](https://esbuild.github.io/api/#format) is set to cjs, which stands for CommonJS (the module format used by node). ES6-style exports using export statements will be converted into getters on the CommonJS exports object.

This package doesn't support ESM yet (at least not intentionally), so this PR:

- Explicitly sets the format to CJS
- Explicitly sets the two inputs to work with

## Testing

You can test that this fix works by first cloning and setting up this repo:

```sh
git clone git@github.com:1Password/op-js.git
cd ./op-js && git checkout jh/fix-cjs
yarn && yarn build
```

Then you can also clone this test repo I set up:

```
git clone git@github.com:jodyheavener/tmp-opjs-test.git
cd ./tmp-opjs-test 
yarn && yarn start
```

This test repo has the `op-js` codebase symlinked as a dependency, so if you've built it locally everything should be working as expected. By comparison, if you were to repeat these steps in the `op-js` repo on `main`, it should fail.