### PR TITLE
Allow section names to be escaped properly

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -10,6 +10,7 @@ import {
 	defaultClientInfo,
 	ExecutionError,
 	parseFlagValue,
+	sanitizeInput,
 	semverToInt,
 	ValidationError,
 } from "./cli";
@@ -145,6 +146,30 @@ describe("camelToHyphen", () => {
 
 	it("correctly handles pascal case", () => {
 		expect(camelToHyphen("SomeFlag")).toEqual("some-flag");
+	});
+});
+
+describe("sanitizeInput", () => {
+	it("should handle special characters", () => {
+		expect(sanitizeInput('abc"test')).toEqual('abc\\"test');
+		expect(sanitizeInput('abc\\"test')).toEqual('abc\\"test');
+
+		expect(sanitizeInput("test.test")).toEqual("test.test");
+		expect(sanitizeInput("test\\.test")).toEqual("test\\.test");
+
+		expect(sanitizeInput("def$test")).toEqual("def\\$test");
+		expect(sanitizeInput("def\\$test")).toEqual("def\\$test");
+
+		expect(sanitizeInput("xyz'test")).toEqual("xyz\\'test");
+		expect(sanitizeInput("xyz\\'test")).toEqual("xyz\\'test");
+
+		expect(sanitizeInput("fds`test")).toEqual("fds\\`test");
+		expect(sanitizeInput("fds\\`test")).toEqual("fds\\`test");
+	});
+
+	it("should handle section delimiter", () => {
+		expect(sanitizeInput("test.test")).toEqual("test.test");
+		expect(sanitizeInput("test\\.test.test")).toEqual("test\\.test.test");
 	});
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,8 +91,24 @@ export const semverToInt = (input: string) =>
 export const camelToHyphen = (str: string) =>
 	str.replace(/([A-Za-z])(?=[A-Z])/g, "$1-").toLowerCase();
 
-export const sanitizeInput = (str: string) =>
-	str.replace(/(["$'\\`])/g, "\\$1");
+const specialCharacters = ['"', "$", "'", "\\", "`"];
+const escapableCharacters = new Set([...specialCharacters, "."]);
+
+export const sanitizeInput = (str: string) => {
+	let newStr = "";
+	for (let i = 0; i < str.length; i++) {
+		if (str[i] === "\\") {
+			const isEscaped = escapableCharacters.has(str[i + 1]);
+			if (!isEscaped) {
+				str += "\\";
+			}
+		} else if (specialCharacters.includes(str[i])) {
+			str += "\\";
+		}
+		newStr += str[i];
+	}
+	return newStr;
+};
 
 const equalArray = (a: any[], b: any[]) =>
 	a.length === b.length && a.every((val, index) => val === b[index]);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,14 +96,16 @@ const escapableCharacters = new Set([...specialCharacters, "."]);
 
 export const sanitizeInput = (str: string) => {
 	let newStr = "";
+	let isEscaped = false;
 	for (let i = 0; i < str.length; i++) {
 		if (str[i] === "\\") {
-			const isEscaped = escapableCharacters.has(str[i + 1]);
+			isEscaped = escapableCharacters.has(str[i + 1]);
 			if (!isEscaped) {
-				str += "\\";
+				newStr += "\\";
 			}
-		} else if (specialCharacters.includes(str[i])) {
-			str += "\\";
+		} else if (!isEscaped && specialCharacters.includes(str[i])) {
+			newStr += "\\";
+			isEscaped = false;
 		}
 		newStr += str[i];
 	}

--- a/tests/item.test.ts
+++ b/tests/item.test.ts
@@ -83,4 +83,24 @@ describe("item", () => {
 		const del = item.delete(create.id);
 		expect(del).toBeUndefined();
 	});
+	it("CRUDs items with sections", () => {
+		const create = item.create([["username", "text", "created"]], {
+			vault: process.env.OP_VAULT,
+			category: "Login",
+			title: "Created Login",
+			url: "https://example.com",
+		});
+		expect(create).toMatchSchema(itemSchema);
+
+		const edit = item.edit(create.id, [["username", "text", "updated"]], {
+			title: "Updated Login",
+		});
+		expect(edit).toMatchSchema(itemSchema);
+
+		const get = item.get(create.id);
+		expect(get).toMatchSchema(itemSchema);
+
+		const del = item.delete(create.id);
+		expect(del).toBeUndefined();
+	});
 });

--- a/tests/item.test.ts
+++ b/tests/item.test.ts
@@ -83,16 +83,18 @@ describe("item", () => {
 		const del = item.delete(create.id);
 		expect(del).toBeUndefined();
 	});
+
 	it("CRUDs items with sections", () => {
-		const create = item.create([["username", "text", "created"]], {
+		const create = item.create([["my\\.section.username", "text", "created"]], {
 			vault: process.env.OP_VAULT,
 			category: "Login",
 			title: "Created Login",
 			url: "https://example.com",
+			generatePassword: true
 		});
 		expect(create).toMatchSchema(itemSchema);
 
-		const edit = item.edit(create.id, [["username", "text", "updated"]], {
+		const edit = item.edit(create.id, [["my\\.section.username", "text", "updated"]], {
 			title: "Updated Login",
 		});
 		expect(edit).toMatchSchema(itemSchema);


### PR DESCRIPTION
Fixes #168

I'm not sure if this is the best way to do it, but it _a_ way to do it. 😄 