### PR TITLE
fix: revoke user from group

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1681,6 +1681,6 @@ export const group = {
 				group: string;
 				user: string;
 			}> = {},
-		) => cli.execute<void>(["group", "user", "grant"], { flags, json: false }),
+		) => cli.execute<void>(["group", "user", "revoke"], { flags, json: false }),
 	},
 };


### PR DESCRIPTION
Fixes a bug that prevents revoking a user's membership from a group. 

Currently the command incorrectly calls grant (without a role parameter), which results in them being updated to the default member role of that group.
