### PR TITLE
Add command line option permission on vault.list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1288,6 +1288,7 @@ export const vault = {
 		flags: CommandFlags<{
 			group: string;
 			user: string;
+			permission: VaultPermisson;
 		}> = {},
 	) => cli.execute<AbbreviatedVault[]>(["vault", "list"], { flags }),
 


### PR DESCRIPTION
Currently you can use a workaround:
```
vault.list({ permission: "allow_editing" } as any);
```