### PR TITLE
chore: add npm metadata links

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
 		"type": "git",
 		"url": "https://github.com/1Password/op-js"
 	},
+	"homepage": "https://github.com/1Password/op-js#readme",
+	"bugs": {
+		"url": "https://github.com/1Password/op-js/issues"
+	},
 	"license": "MIT",
 	"scripts": {
 		"build": "license-checker-rseidelsohn --direct --files licenses && yarn compile --minify && tsc -p tsconfig.release.json --emitDeclarationOnly",


### PR DESCRIPTION
## Summary
- add npm homepage metadata for the repository README
- add npm bugs metadata pointing to the GitHub issue tracker

## Validation
- metadata smoke check for `homepage`, `bugs`, and `repository`
- `git diff --check`
