### PR TITLE
Add npm support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
 		"type": "git",
 		"url": "https://github.com/1Password/op-js"
 	},
+	"homepage": "https://github.com/1Password/op-js#readme",
+	"bugs": {
+		"url": "https://github.com/1Password/op-js/issues"
+	},
 	"license": "MIT",
 	"scripts": {
 		"build": "license-checker-rseidelsohn --direct --files licenses && yarn compile --minify && tsc -p tsconfig.release.json --emitDeclarationOnly",


### PR DESCRIPTION
## Summary

- add `homepage` metadata for the published `@1password/op-js` npm package
- add `bugs.url` metadata pointing npm users to this repository's issue tracker
- leave runtime code, dependencies, exports, and package contents unchanged

## Why

The current `@1password/op-js@0.1.13` package exposes its repository but omits `homepage` and `bugs` metadata, so npm clients do not show the README or issue tracker links directly from package metadata.

This is also the upstream fix for the public reproducibility lead I filed at charles-openclaw/charles-microbounties#869.

## Verification

```sh
node - <<'NODE'
const fs = require('fs');
const p = JSON.parse(fs.readFileSync('package.json', 'utf8'));
if (p.homepage !== 'https://github.com/1Password/op-js#readme') throw new Error('missing homepage');
if (p.bugs?.url !== 'https://github.com/1Password/op-js/issues') throw new Error('missing bugs.url');
console.log(JSON.stringify({ name: p.name, homepage: p.homepage, bugs: p.bugs }, null, 2));
NODE

git diff --check
npm pack --dry-run --ignore-scripts --json
```
